### PR TITLE
Fix guard-aux

### DIFF
--- a/srfi-34.html
+++ b/srfi-34.html
@@ -258,7 +258,7 @@ PRINTS: reraised 0
            (result temp)
            (guard-aux reraise clause1 clause2 ...))))
     ((guard-aux reraise (test))
-     test)
+     (or test reraise))
     ((guard-aux reraise (test) clause1 clause2 ...)
      (let ((temp test))
        (if temp


### PR DESCRIPTION
Hello.
I found a problem of 'guard-aux' in the reference implementation of srfi-34.
This has already been fixed in R7RS (7.3).
Therefore I fixed it in the same way.
I hope this is useful for Scheme users.
